### PR TITLE
[4] Add configurable field scraping for performance optimization

### DIFF
--- a/examples/get_profile_example.py
+++ b/examples/get_profile_example.py
@@ -7,7 +7,7 @@ import os
 
 from dotenv import load_dotenv
 
-from fast_linkedin_scraper import LinkedInSession
+from fast_linkedin_scraper import LinkedInSession, ScrapingFields
 from fast_linkedin_scraper.models import Person
 
 load_dotenv()
@@ -27,11 +27,49 @@ os.makedirs(output_dir, exist_ok=True)
 async def main():
     assert cookie is not None  # Type narrowing for type checker
     async with LinkedInSession.from_cookie(cookie, headless=False) as session:
-        # Scrape the profile
-        person: Person = await session.get_profile(PROFILE_URL)
+        # Example 1: Minimal scraping (fastest - only basic info)
+        print("=== Minimal scraping (basic info only) ===")
+        person_minimal: Person = await session.get_profile(
+            PROFILE_URL, fields=ScrapingFields.MINIMAL
+        )
+        print(f"Name: {person_minimal.name}")
+        print(f"Headline: {person_minimal.headline}")
+        print(f"Location: {person_minimal.location}")
+        print()
 
-        # Print the person object as pretty JSON
-        print(json.dumps(person.model_dump(), indent=2, default=str))
+        # Example 2: Career-focused scraping (basic info + experience + education)
+        print("=== Career scraping (basic + experience + education) ===")
+        person_career: Person = await session.get_profile(
+            PROFILE_URL, fields=ScrapingFields.CAREER
+        )
+        print(f"Name: {person_career.name}")
+        print(f"Experience count: {len(person_career.experiences)}")
+        print(f"Education count: {len(person_career.educations)}")
+        print()
+
+        # Example 3: Specific fields
+        print("=== Custom field selection ===")
+        custom_fields = (
+            ScrapingFields.BASIC_INFO
+            | ScrapingFields.EXPERIENCE
+            | ScrapingFields.CONTACTS
+        )
+        person_custom: Person = await session.get_profile(
+            PROFILE_URL, fields=custom_fields
+        )
+        print(f"Name: {person_custom.name}")
+        print(f"Experience count: {len(person_custom.experiences)}")
+        print(f"Connection count: {person_custom.connection_count}")
+        print()
+
+        # Example 4: All fields (slowest but most complete)
+        print("=== All fields (complete profile) ===")
+        person_all: Person = await session.get_profile(
+            PROFILE_URL, fields=ScrapingFields.ALL
+        )
+
+        # Print the complete person object as pretty JSON
+        print(json.dumps(person_all.model_dump(), indent=2, default=str))
 
 
 if __name__ == "__main__":

--- a/fast_linkedin_scraper/__init__.py
+++ b/fast_linkedin_scraper/__init__.py
@@ -3,6 +3,7 @@
 from .session import LinkedInSession
 from .auth import PasswordAuth, CookieAuth
 from .browser import BrowserContextManager
+from .config import ScrapingFields
 
 __version__ = "2.11.5"
 
@@ -11,4 +12,5 @@ __all__ = [
     "PasswordAuth",
     "CookieAuth",
     "BrowserContextManager",
+    "ScrapingFields",
 ]

--- a/fast_linkedin_scraper/config.py
+++ b/fast_linkedin_scraper/config.py
@@ -1,5 +1,6 @@
 """Configuration settings for the LinkedIn scraper."""
 
+from enum import Flag, auto
 from playwright.async_api import ViewportSize
 
 
@@ -23,3 +24,19 @@ class BrowserConfig:
         "--disable-backgrounding-occluded-windows",
         "--disable-renderer-backgrounding",
     ]
+
+
+class ScrapingFields(Flag):
+    """Fields that can be scraped from LinkedIn profiles."""
+
+    BASIC_INFO = auto()
+    EXPERIENCE = auto()
+    EDUCATION = auto()
+    INTERESTS = auto()
+    ACCOMPLISHMENTS = auto()
+    CONTACTS = auto()
+
+    # Presets
+    MINIMAL = BASIC_INFO
+    CAREER = BASIC_INFO | EXPERIENCE | EDUCATION
+    ALL = BASIC_INFO | EXPERIENCE | EDUCATION | INTERESTS | ACCOMPLISHMENTS | CONTACTS

--- a/fast_linkedin_scraper/session.py
+++ b/fast_linkedin_scraper/session.py
@@ -4,6 +4,7 @@ from playwright.async_api import Page
 
 from .auth import CookieAuth, LinkedInAuth, PasswordAuth
 from .browser import BrowserContextManager
+from .config import ScrapingFields
 from .models.person import Person
 
 
@@ -83,11 +84,14 @@ class LinkedInSession:
             )
         return self._page
 
-    async def get_profile(self, url: str) -> Person:
+    async def get_profile(
+        self, url: str, fields: ScrapingFields = ScrapingFields.MINIMAL
+    ) -> Person:
         """Get LinkedIn profile data.
 
         Args:
             url: LinkedIn profile URL
+            fields: ScrapingFields enum specifying which fields to scrape
 
         Returns:
             Person object with scraped profile data
@@ -99,7 +103,7 @@ class LinkedInSession:
 
         page: Page = self._ensure_authenticated()
         scraper: PersonScraper = PersonScraper(page)
-        return await scraper.scrape_profile(url)
+        return await scraper.scrape_profile(url, fields)
 
     async def get_company(self, url: str) -> dict:
         """Get LinkedIn company data.

--- a/tests/get_profile_test.py
+++ b/tests/get_profile_test.py
@@ -7,7 +7,7 @@ import os
 
 from dotenv import load_dotenv
 
-from fast_linkedin_scraper import LinkedInSession
+from fast_linkedin_scraper import LinkedInSession, ScrapingFields
 from fast_linkedin_scraper.models import Person
 
 load_dotenv()
@@ -28,10 +28,12 @@ output_dir = "output"
 async def main():
     assert cookie is not None  # Type narrowing for type checker
     async with LinkedInSession.from_cookie(cookie, headless=False) as session:
-        # Scrape both profiles
+        # Scrape both profiles with all fields for comprehensive testing
         for username in USERNAMES:
             profile_url = f"https://www.linkedin.com/in/{username}/"
-            person: Person = await session.get_profile(profile_url)
+            person: Person = await session.get_profile(
+                profile_url, fields=ScrapingFields.ALL
+            )
 
             # Print the person object as pretty JSON
             # print(json.dumps(person.model_dump(), indent=2, default=str))


### PR DESCRIPTION
## Summary
- Add ScrapingFields enum with BASIC_INFO, EXPERIENCE, EDUCATION, INTERESTS, ACCOMPLISHMENTS, CONTACTS fields
- Default to minimal scraping (BASIC_INFO only) for improved performance
- Provide presets: MINIMAL, CAREER (basic+experience+education), ALL

## Usage
```python
# Minimal (fastest)
person = await session.get_profile(url)

# Career info
person = await session.get_profile(url, fields=ScrapingFields.CAREER)

# Custom combination
fields = ScrapingFields.BASIC_INFO | ScrapingFields.EXPERIENCE
person = await session.get_profile(url, fields=fields)
```

Resolves #4